### PR TITLE
Improve login and signup flow

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -45,7 +45,7 @@ const navigationItems = [
 export default function Layout({ children, currentPageName }) {
   const location = useLocation();
 
-  if (currentPageName === "Landing") {
+  if (["Landing", "Login", "Signup"].includes(currentPageName)) {
     return <div className="min-h-screen">{children}</div>;
   }
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -2,10 +2,13 @@
 import React, { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Link } from "react-router-dom";
 
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [remember, setRemember] = useState(false);
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-slate-50">
@@ -15,13 +18,13 @@ export default function Login() {
         className="w-full max-w-md space-y-6 bg-white p-8 rounded-lg shadow"
       >
         <h1 className="text-2xl font-bold text-center">Log In</h1>
+        <p className="text-sm text-center text-slate-600">
+          Welcome back! Please enter your details below.
+        </p>
         <div className="text-center">
-          <a
-            href="/auth/google"
-            className="inline-block w-full mb-4"
-          >
+          <a href="/auth/google" className="inline-block w-full mb-4">
             <Button type="button" variant="outline" className="w-full">
-              Log In with Google
+              Continue with Google
             </Button>
           </a>
         </div>
@@ -51,9 +54,24 @@ export default function Login() {
             onChange={(e) => setPassword(e.target.value)}
           />
         </div>
+        <div className="flex items-center justify-between">
+          <label htmlFor="remember" className="flex items-center gap-2 text-sm">
+            <Checkbox id="remember" checked={remember} onCheckedChange={setRemember} />
+            Remember me
+          </label>
+          <a href="#" className="text-sm text-blue-600 hover:underline">
+            Forgot password?
+          </a>
+        </div>
         <Button type="submit" className="w-full bg-blue-600 hover:bg-blue-700">
           Log In
         </Button>
+        <p className="text-sm text-center text-slate-600">
+          Don't have an account?{' '}
+          <Link to="/Signup" className="text-blue-600 hover:underline">
+            Sign up
+          </Link>
+        </p>
       </form>
     </div>
   );

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,10 +1,14 @@
 import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Link } from "react-router-dom";
 
 export default function Signup() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [agree, setAgree] = useState(false);
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-slate-50">
@@ -14,10 +18,13 @@ export default function Signup() {
         className="w-full max-w-md space-y-6 bg-white p-8 rounded-lg shadow"
       >
         <h1 className="text-2xl font-bold text-center">Sign Up</h1>
+        <p className="text-sm text-center text-slate-600">
+          Create your account or continue with Google.
+        </p>
         <div className="text-center">
           <a href="/auth/google" className="inline-block w-full mb-4">
             <Button type="button" variant="outline" className="w-full">
-              Sign Up with Google
+              Continue with Google
             </Button>
           </a>
         </div>
@@ -47,9 +54,40 @@ export default function Signup() {
             onChange={(e) => setPassword(e.target.value)}
           />
         </div>
-        <Button type="submit" className="w-full bg-blue-600 hover:bg-blue-700">
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-slate-700" htmlFor="confirm">
+            Confirm Password
+          </label>
+          <Input
+            id="confirm"
+            name="confirm"
+            type="password"
+            required
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+          />
+        </div>
+        <div className="flex items-center">
+          <Checkbox id="terms" checked={agree} onCheckedChange={setAgree} />
+          <label htmlFor="terms" className="ml-2 text-sm">
+            I agree to the{' '}
+            <a href="#" className="underline">
+              Terms
+            </a>{' '}and{' '}
+            <a href="#" className="underline">
+              Privacy Policy
+            </a>
+          </label>
+        </div>
+        <Button type="submit" className="w-full bg-blue-600 hover:bg-blue-700" disabled={!agree}>
           Sign Up
         </Button>
+        <p className="text-sm text-center text-slate-600">
+          Already have an account?{' '}
+          <Link to="/Login" className="text-blue-600 hover:underline">
+            Log in
+          </Link>
+        </p>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- add "Remember me", Google login and sign up links on `Login`
- expand `Signup` with confirm password, terms agreement and login link
- hide sidebar for login and signup pages

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885bc2d96c8832795ec8c5582133a39