### PR TITLE
Remove module type from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "casegen-app",
   "private": true,
   "version": "0.0.0",
-  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- remove `"type": "module"` from `package.json` to revert to CommonJS

## Testing
- `npm ci`
- `npm run lint` *(fails: 'module' is not defined; 502 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6885cf48602c8327942528752ca1fd72