### PR TITLE
Redirect signup to dashboard

### DIFF
--- a/pages/signup.jsx
+++ b/pages/signup.jsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Signup() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/dashboard');
+  }, [router]);
+
+  return null;
+}
+
+export async function getServerSideProps() {
+  return {
+    redirect: {
+      destination: '/dashboard',
+      permanent: false,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add new `/signup` Next.js page
- redirect to `/dashboard` on client with `useEffect`
- use `getServerSideProps` for server-side redirect

## Testing
- `npm install`
- `npx eslint .` *(fails: numerous errors in repo)*
- `npm test` *(fails: no test script defined)*

------
https://chatgpt.com/codex/tasks/task_e_6885f1e844a08327b15d87773b506429