### PR TITLE
Add login route and NextAuth callbacks

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -13,6 +13,32 @@ export const authOptions = {
       },
     }),
   ],
+
+  callbacks: {
+    async redirect({ url, baseUrl }) {
+      return `${baseUrl}/`;
+    },
+
+    async jwt({ token, account, profile }) {
+      if (account) {
+        token.accessToken = account.access_token;
+        token.id = profile.sub;
+      }
+      return token;
+    },
+
+    async session({ session, token }) {
+      session.accessToken = token.accessToken;
+      session.user.id = token.id;
+      return session;
+    },
+  },
+
+  pages: {
+    signIn: '/login',
+    error: '/auth/error',
+  },
+
   secret: process.env.NEXTAUTH_SECRET,
 };
 

--- a/pages/auth/error.js
+++ b/pages/auth/error.js
@@ -1,0 +1,7 @@
+export default function AuthError() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <h1>Authentication Error</h1>
+    </div>
+  );
+}

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,48 @@
+import { useSession, signIn } from 'next-auth/react';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export default function Login() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (session) {
+      router.push('/');
+    }
+  }, [session, router]);
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">Loading...</div>
+    );
+  }
+
+  if (session) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full space-y-8 p-8">
+        <div className="text-center">
+          <h2 className="text-3xl font-bold text-gray-900 mb-6">
+            Sign in to Case Generator
+          </h2>
+          <button
+            onClick={() => signIn('google')}
+            className="w-full flex items-center justify-center px-4 py-2 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50"
+          >
+            <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
+              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+            </svg>
+            Sign in with Google
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/login` Next.js page with Google sign-in
- add simple auth error page
- configure NextAuth to use callbacks, `/login` and basic redirects

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886076ec0c48327ae41a391f8ee081f