### PR TITLE
Add PLG onboarding flow

### DIFF
--- a/pages/onboarding.js
+++ b/pages/onboarding.js
@@ -1,0 +1,119 @@
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { signIn, useSession } from 'next-auth/react';
+
+function WelcomeStep({ onNext }) {
+  return (
+    <div className="text-center space-y-4">
+      <h2 className="text-2xl font-bold">Welcome to CaseGen</h2>
+      <p className="text-gray-600">Answer a few quick questions to personalize your first case study.</p>
+      <button className="bg-blue-600 text-white px-6 py-3 rounded" onClick={onNext}>Get Started</button>
+    </div>
+  );
+}
+
+function GoalsStep({ userData, setUserData, onNext }) {
+  const goals = [
+    { id: 'job_prep', title: 'Land a Finance Job' },
+    { id: 'skill_building', title: 'Build DCF Skills' },
+    { id: 'work_projects', title: 'Analyze Real Deals' }
+  ];
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold text-center">What brings you here?</h2>
+      {goals.map(goal => (
+        <button
+          key={goal.id}
+          className="w-full p-4 border rounded hover:bg-blue-50 text-left"
+          onClick={() => { setUserData({ ...userData, goal: goal.id }); onNext(); }}
+        >
+          {goal.title}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ExperienceStep({ userData, setUserData, onNext }) {
+  const levels = [
+    { id: 'beginner', title: 'New to Finance' },
+    { id: 'intermediate', title: 'Some Experience' },
+    { id: 'advanced', title: 'Finance Professional' }
+  ];
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold text-center">Your experience level?</h2>
+      {levels.map(level => (
+        <button
+          key={level.id}
+          className="w-full p-4 border rounded hover:bg-blue-50 text-left"
+          onClick={() => { setUserData({ ...userData, experience: level.id }); onNext(); }}
+        >
+          {level.title}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function FirstCaseStep({ userData }) {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    setIsGenerating(true);
+    const t = setTimeout(() => {
+      setIsGenerating(false);
+    }, 1500);
+    return () => clearTimeout(t);
+  }, []);
+
+  if (isGenerating) {
+    return (
+      <div className="text-center">
+        <p className="text-lg">Generating your personalized case...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center space-y-4">
+      <h2 className="text-2xl font-bold">Your Case Study is Ready!</h2>
+      <p className="text-gray-600">Goal: {userData.goal || '-'}, Level: {userData.experience || '-'}</p>
+      <button className="bg-blue-600 text-white px-6 py-3 rounded" onClick={() => router.push('/Dashboard')}>
+        Go to Dashboard
+      </button>
+    </div>
+  );
+}
+
+export default function Onboarding() {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const [step, setStep] = useState(1);
+  const [userData, setUserData] = useState({});
+
+  useEffect(() => {
+    if (!session) {
+      signIn('google', { callbackUrl: '/onboarding' });
+    }
+  }, [session]);
+
+  const steps = [
+    { id: 1, component: WelcomeStep },
+    { id: 2, component: GoalsStep },
+    { id: 3, component: ExperienceStep },
+    { id: 4, component: FirstCaseStep }
+  ];
+
+  const StepComponent = steps[step - 1].component;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-6">
+      <div className="max-w-md w-full space-y-6 bg-white p-8 rounded-lg shadow">
+        <div className="text-right text-sm text-gray-500">Step {step} of {steps.length}</div>
+        <StepComponent userData={userData} setUserData={setUserData} onNext={() => setStep(step + 1)} />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,0 +1,25 @@
+export const ONBOARDING_EVENTS = {
+  landing_page_view: { page: 'landing' },
+  signup_started: { method: 'google' },
+  signup_completed: { user_id: null },
+  onboarding_started: { step: 1 },
+  goal_selected: { goal: null },
+  experience_selected: { level: null },
+  first_case_generated: { case_id: null },
+  onboarding_completed: { time_to_complete: null },
+  upgrade_prompt_shown: { trigger: null },
+  upgrade_clicked: { plan: null },
+  subscription_started: { plan: null, trial: false }
+};
+
+export const trackOnboardingEvent = (eventName, properties = {}) => {
+  if (typeof window === 'undefined') return;
+  const payload = {
+    ...ONBOARDING_EVENTS[eventName],
+    ...properties,
+    event: eventName,
+    timestamp: new Date().toISOString()
+  };
+  // Placeholder: send to analytics provider
+  console.log('analytics', payload);
+};

--- a/src/lib/subscription.js
+++ b/src/lib/subscription.js
@@ -1,0 +1,45 @@
+export const PLANS = {
+  free: {
+    name: 'Free',
+    price: 0,
+    features: {
+      casesPerMonth: 3,
+      modelDownloads: true,
+      basicTemplates: true,
+      communitySupport: true,
+      advancedAnalytics: false,
+      prioritySupport: false,
+      customScenarios: false
+    }
+  },
+  pro: {
+    name: 'Pro',
+    price: 29,
+    features: {
+      casesPerMonth: 50,
+      modelDownloads: true,
+      basicTemplates: true,
+      communitySupport: true,
+      advancedAnalytics: true,
+      prioritySupport: true,
+      customScenarios: true,
+      exportOptions: true
+    }
+  },
+  enterprise: {
+    name: 'Enterprise',
+    price: 99,
+    features: {
+      casesPerMonth: 'unlimited',
+      modelDownloads: true,
+      basicTemplates: true,
+      communitySupport: true,
+      advancedAnalytics: true,
+      prioritySupport: true,
+      customScenarios: true,
+      exportOptions: true,
+      teamCollaboration: true,
+      whiteLabel: true
+    }
+  }
+};

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,5 +1,6 @@
 
 import { useState } from "react";
+import { signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -26,16 +27,7 @@ export default function Landing() {
   const navigate = useNavigate();
 
   const handleStartFree = async () => {
-    try {
-      const user = await User.me();
-      if (user?.subscription_tier) {
-        navigate(createPageUrl("Dashboard"));
-      } else {
-        navigate(createPageUrl("Signup"));
-      }
-    } catch (e) {
-      navigate(createPageUrl("Signup"));
-    }
+    await signIn("google", { callbackUrl: "/onboarding" });
   };
 
   const handleLogin = async () => {


### PR DESCRIPTION
## Summary
- add new `/onboarding` page with simple multi-step flow
- include subscription plan and analytics helpers
- update landing page start button to send new users to Google OAuth with onboarding callback

## Testing
- `npm run lint` *(fails: numerous prop-types errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68860d4e04388327a41b96ee878c1b07