### PR TITLE
Fix auth redirects and pricing page

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -16,7 +16,7 @@ export const authOptions = {
 
   callbacks: {
     async redirect({ url, baseUrl }) {
-      return `${baseUrl}/`;
+      return `${baseUrl}/dashboard`;
     },
 
     async jwt({ token, account, profile }) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,31 @@
 import dynamic from 'next/dynamic';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 const App = dynamic(() => import('../src/App.jsx'), { ssr: false });
 
-export default function IndexPage() {
+export default function LandingPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (session) {
+      router.push('/dashboard');
+    }
+  }, [session, router]);
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div>Loading...</div>
+      </div>
+    );
+  }
+
+  if (session) {
+    return null;
+  }
+
   return <App />;
 }

--- a/pages/onboarding.js
+++ b/pages/onboarding.js
@@ -80,7 +80,7 @@ function FirstCaseStep({ userData }) {
     <div className="text-center space-y-4">
       <h2 className="text-2xl font-bold">Your Case Study is Ready!</h2>
       <p className="text-gray-600">Goal: {userData.goal || '-'}, Level: {userData.experience || '-'}</p>
-      <button className="bg-blue-600 text-white px-6 py-3 rounded" onClick={() => router.push('/Dashboard')}>
+      <button className="bg-blue-600 text-white px-6 py-3 rounded" onClick={() => router.push('/dashboard')}>
         Go to Dashboard
       </button>
     </div>

--- a/pages/pricing.js
+++ b/pages/pricing.js
@@ -1,0 +1,159 @@
+// pages/pricing.js
+import { useSession, signIn } from 'next-auth/react';
+import { useRouter } from 'next/router';
+
+export default function Pricing() {
+  const { data: session } = useSession();
+  const router = useRouter();
+
+  const plans = [
+    {
+      name: 'Free',
+      price: '$0',
+      period: 'forever',
+      features: [
+        '3 case studies per month',
+        'Basic DCF templates',
+        'Model downloads'
+      ],
+      cta: session ? 'Current Plan' : 'Start Free',
+      popular: false
+    },
+    {
+      name: 'Pro',
+      price: '$29',
+      period: 'per month',
+      features: [
+        '30 case studies per month',
+        'All templates',
+        'Priority support',
+        'Custom scenarios',
+        'Export options'
+      ],
+      cta: session ? 'Upgrade to Pro' : 'Start Pro Trial',
+      popular: true
+    },
+    {
+      name: 'Enterprise',
+      price: '$99',
+      period: 'per month',
+      features: [
+        'Unlimited case studies',
+        'Team collaboration',
+        'White-label option',
+        'Dedicated support',
+        'Custom integrations',
+        'Advanced reporting'
+      ],
+      cta: session ? 'Contact Sales' : 'Contact Sales',
+      popular: false
+    }
+  ];
+
+  const handlePlanSelect = (plan) => {
+    if (!session) {
+      signIn('google', { callbackUrl: '/pricing' });
+      return;
+    }
+
+    if (plan.name === 'Free') {
+      router.push('/dashboard');
+    } else if (plan.name === 'Pro') {
+      alert('Pro subscription coming soon!');
+    } else {
+      alert('Contact sales coming soon!');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto px-6 py-4 flex justify-between items-center">
+          <button
+            onClick={() => router.push('/')}
+            className="text-2xl font-bold text-blue-600"
+          >
+            CaseGen
+          </button>
+          <div className="flex gap-4">
+            {session ? (
+              <button
+                onClick={() => router.push('/dashboard')}
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+              >
+                Dashboard
+              </button>
+            ) : (
+              <button
+                onClick={() => signIn('google')}
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+              >
+                Sign In
+              </button>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-6 py-20">
+        <div className="text-center mb-16">
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">
+            Choose Your Plan
+          </h1>
+          <p className="text-xl text-gray-600">
+            Start free, upgrade when you need more
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+          {plans.map((plan) => (
+            <div
+              key={plan.name}
+              className={`bg-white rounded-lg shadow-lg p-8 relative ${
+                plan.popular ? 'border-2 border-blue-500' : 'border border-gray-200'
+              }`}
+            >
+              {plan.popular && (
+                <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
+                  <span className="bg-blue-500 text-white px-4 py-1 rounded-full text-sm font-medium">
+                    Most Popular
+                  </span>
+                </div>
+              )}
+              
+              <div className="text-center mb-8">
+                <h3 className="text-2xl font-bold text-gray-900 mb-2">{plan.name}</h3>
+                <div className="mb-4">
+                  <span className="text-4xl font-bold text-gray-900">{plan.price}</span>
+                  <span className="text-gray-600 ml-2">{plan.period}</span>
+                </div>
+              </div>
+
+              <ul className="space-y-3 mb-8">
+                {plan.features.map((feature, index) => (
+                  <li key={index} className="flex items-center gap-3">
+                    <svg className="w-5 h-5 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                    </svg>
+                    <span className="text-gray-700">{feature}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <button
+                onClick={() => handlePlanSelect(plan)}
+                className={`w-full py-3 px-6 rounded-lg font-semibold transition-colors ${
+                  plan.popular
+                    ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                    : 'border border-blue-600 text-blue-600 hover:bg-blue-50'
+                }`}
+              >
+                {plan.cta}
+              </button>
+            </div>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, Suspense } from "react";
 import { Case } from "@/api/entities";
 import { User } from "@/api/entities";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { createPageUrl } from "@/utils";
 import { Plus, FileText, TrendingUp } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { useSession, signOut } from "next-auth/react";
 
 import DashboardHeader from "../components/dashboard/DashboardHeader";
 import DashboardStats from "../components/dashboard/DashboardStats";
@@ -17,12 +18,18 @@ export default function Dashboard() {
   const [cases, setCases] = useState([]);
   const [user, setUser] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+  const { data: session, status } = useSession();
+  const navigate = useNavigate();
 
   useEffect(() => {
-    loadDashboardData();
-  }, []);
+    if (status === 'unauthenticated') {
+      navigate('/login');
+    } else if (status === 'authenticated') {
+      loadDashboardData();
+    }
+  }, [status]);
 
-  const loadDashboardData = async () => {
+    const loadDashboardData = async () => {
     setIsLoading(true);
     try {
       const [casesData, userData] = await Promise.all([
@@ -32,12 +39,12 @@ export default function Dashboard() {
       setCases(casesData);
       setUser(userData);
       if (!userData?.subscription_tier) {
-        window.location.href = "/signup";
+        navigate('/signup');
         return;
       }
     } catch (error) {
       console.error("Error loading dashboard data:", error);
-      window.location.href = "/login";
+      navigate('/login');
       return;
     }
     setIsLoading(false);
@@ -46,9 +53,36 @@ export default function Dashboard() {
   const completedCases = cases.filter(c => c.status === 'completed');
   const inProgressCases = cases.filter(c => c.status === 'awaiting_results' || c.status === 'generating');
 
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-lg">Loading dashboard...</div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return null;
+  }
+
   return (
-    <div className="p-6 lg:p-8 max-w-7xl mx-auto space-y-6">
-      <DashboardHeader user={user} />
+    <div>
+      <div className="bg-white border-b px-6 py-3 flex justify-between items-center">
+        <h1 className="text-lg font-semibold">Dashboard</h1>
+        <div className="flex items-center gap-4">
+          <span className="text-sm text-gray-600">
+            Welcome, {session.user.name || session.user.email}
+          </span>
+          <button
+            onClick={() => signOut()}
+            className="text-sm text-red-600 hover:text-red-800"
+          >
+            Sign Out
+          </button>
+        </div>
+      </div>
+      <div className="p-6 lg:p-8 max-w-7xl mx-auto space-y-6">
+        <DashboardHeader user={user} />
       
       <DashboardStats 
         totalCases={cases.length}
@@ -66,7 +100,8 @@ export default function Dashboard() {
         </Suspense>
       </div>
 
-      <RecentCasesTable cases={cases.slice(0, 5)} isLoading={isLoading} />
+        <RecentCasesTable cases={cases.slice(0, 5)} isLoading={isLoading} />
+      </div>
     </div>
   );
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -64,7 +64,7 @@ function PagesContent() {
                     <Route path="/" element={<Landing />} />
                 
                 
-                <Route path="/Dashboard" element={<Dashboard />} />
+                <Route path="/dashboard" element={<Dashboard />} />
                 
                 <Route path="/Generate" element={<Generate />} />
                 


### PR DESCRIPTION
## Summary
- send users to `/dashboard` after auth events
- make the landing page session-aware
- add session checks to the Dashboard page
- create a new pricing page
- adjust onboarding button and router path

## Testing
- `npm install`
- `npx eslint .` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68861117446483278e524b4cd8c18541